### PR TITLE
Removed wrong fix attempt for overlap box text alignment #77

### DIFF
--- a/src/illustrations/OverlapBox.scss
+++ b/src/illustrations/OverlapBox.scss
@@ -61,7 +61,6 @@
     width: 50%;
     text-align: center;
     position: relative;
-	min-height: 70px;
 
     div {
       position: absolute;


### PR DESCRIPTION
- it caused problems when actual height would naturally be under 70px